### PR TITLE
ASC-1169 Fix RPC-O Version Detection

### DIFF
--- a/playbooks/pre_deploy.yml
+++ b/playbooks/pre_deploy.yml
@@ -9,7 +9,7 @@
   tasks:
     - name: Get rpc_release (not newton)
       shell: |
-        /opt/rpc-openstack/scripts/get-rpc_release.py -f /opt/rpc-openstack/playbooks/vars/rpc-release.yml
+        /opt/rpc-openstack/scripts/get-rpc_release.py -f /opt/rpc-openstack/playbooks/vars/rpc-release.yml -r {{ vm_branch }}
       register: rpc_release_a
       when: vm_branch != 'newton'
 


### PR DESCRIPTION
The 'get-rpc_release.py' script determines the RPC-O codename by inspecting
the env var 'RPC_PRODUCT_RELEASE' which may not be set. Updated the call
to the 'get-rpc_release.py' script to instead specify the desired RPC-O
release via a command-line argument.