### PR TITLE
ASC-1407 Configure RPC-O Deployments for Testing

### DIFF
--- a/playbooks/configure_tmux.yml
+++ b/playbooks/configure_tmux.yml
@@ -1,0 +1,9 @@
+---
+- hosts: hosts
+  user: ubuntu
+  become: True
+  tasks:
+    - name: Increase Default tmux Scrollback Buffer
+      copy:
+        content: "set-option -g history-limit 40000"
+        dest: ~/.tmux.conf

--- a/playbooks/install_pip_packages.yml
+++ b/playbooks/install_pip_packages.yml
@@ -7,3 +7,5 @@
         name: "{{ item }}"
       with_items:
         - pyaml
+        - python-openstackclient
+        - rpc-zigzag

--- a/playbooks/main.yml
+++ b/playbooks/main.yml
@@ -6,3 +6,5 @@
 - import_playbook: clone_rpc_openstack.yml
 - import_playbook: pre_deploy.yml
 - import_playbook: molecule_test_setup.yml
+- import_playbook: configure_tmux.yml
+- import_playbook: setup_bash_aliases.yml

--- a/playbooks/setup_bash_aliases.yml
+++ b/playbooks/setup_bash_aliases.yml
@@ -1,0 +1,17 @@
+---
+- hosts: hosts
+  user: ubuntu
+  become: True
+  tasks:
+    - name: Add Bash Aliases
+      lineinfile:
+        dest: "~/.bash_aliases"
+        create: yes
+        mode: 0644
+        line: 'alias {{ item.alias }}="{{ item.command }}"'
+        regexp: "^alias {{ item.alias }}="
+      with_items:
+        - alias: os
+          command: openstack --os-cloud default
+        - alias: zz
+          command: zigzag


### PR DESCRIPTION
Update the configuration tasks for deploying RPC-O images to Phobos to include:

- Increase default tmux scrollback to 40,000 lines
- Install the openstack CLI on the deployment host to easily inspect RPC-O infra after a test run
- Install ZigZag on the deployment host so that automation engineers can upload test results to qTest for easier inspection
- Create an alias on the deployment host to launch the openstack CLI with the necessary options to connect to the RPC-O infrastructure
- Create an alias for running ZigZag.