### PR TITLE
ASC-1407 Install Required Packages

### DIFF
--- a/playbooks/install_packages.yml
+++ b/playbooks/install_packages.yml
@@ -9,3 +9,5 @@
       with_items:
         - git-core
         - screen
+        - libc6-dev
+        - python-dev


### PR DESCRIPTION
Something changed from yesterday to today when it comes to default packages.
Adding the 'lib6-dev' and 'python-dev' packages to guarantee that the
'python-openstackclient' Python package can be built properly.