### PR TITLE
ASC-1407 Fix Incorrect Path for tmux Config

### DIFF
--- a/playbooks/configure_tmux.yml
+++ b/playbooks/configure_tmux.yml
@@ -1,7 +1,6 @@
 ---
 - hosts: hosts
   user: ubuntu
-  become: True
   tasks:
     - name: Increase Default tmux Scrollback Buffer
       copy:


### PR DESCRIPTION
Using 'become' was not a good idea because it redirected the tmux config to the
'root' user home directory. It needs to be in the 'ubuntu' home directory.